### PR TITLE
Clarify guardar_ajustes_mps behavior

### DIFF
--- a/server/app/services/mps.py
+++ b/server/app/services/mps.py
@@ -277,16 +277,20 @@ def guardar_ajustes_mps(
 ) -> bool:
     """
     Guarda los ajustes del MPS para un SKU.
-    
+
+    Actualmente es un stub y simplemente devuelve ``True`` sin
+    persistir los datos en la base de datos.
+
     Args:
         db: Sesión de base de datos
         sku_id: ID del SKU
         stock_seguridad: Diccionario de stock de seguridad por semana
         scrap: Diccionario de scrap por semana
-    
+
     Returns:
-        True si se guardó correctamente, False en caso contrario
+        ``True`` si se guardó correctamente, ``False`` en caso contrario
     """
+    # TODO: Persistir ajustes de MPS en la base de datos
     # En una implementación real, estos ajustes se guardarían en una tabla
     # Por ahora, simplemente devolvemos True
     return True


### PR DESCRIPTION
## Summary
- document that `guardar_ajustes_mps` currently returns `True` without saving
- add TODO for future database persistence

## Testing
- `pytest -q`
- `python -m flake8` *(fails: No module named flake8)*

------
https://chatgpt.com/codex/tasks/task_e_684bd48857588333b46c4cf8e36432a3