### PR TITLE
Fix BaseSettings import for Pydantic v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ installed. Python 3.10 or newer is recommended.
    ```
 3. **Install the dependencies** for both the backend and the frontend:
 
-   ```bash
-   pip install -r server/requirements.txt -r client/requirements.txt
-   ```
+ ```bash
+  pip install -r server/requirements.txt -r client/requirements.txt
+  ```
+   This installs all required packages, including
+   `pydantic-settings` which is needed for the configuration
+   classes in the backend.
 4. **Create environment files** from the provided examples:
 
    ```bash

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -1,36 +1,40 @@
-from pydantic import BaseSettings
-from typing import Optional
+from pydantic_settings import BaseSettings
 import os
 from dotenv import load_dotenv
 
 # Cargar variables de entorno
 load_dotenv()
 
+
 class Settings(BaseSettings):
     """
     Configuración de la aplicación.
     """
+
     # Base de datos
     DATABASE_URL: str = os.getenv("DATABASE_URL", "sqlite:///./app.db")
-    
+
     # Puerto del servidor
     PORT: int = int(os.getenv("PORT", "8000"))
-    
+
     # Nivel de servicio para stock de seguridad (0-1)
     NIVEL_SERVICIO: float = float(os.getenv("NIVEL_SERVICIO", "0.95"))
-    
+
     # Capacidad semanal en kg de café verde
     CAPACIDAD_SEMANAL: float = float(os.getenv("CAPACIDAD_SEMANAL", "300"))
-    
+
     # Objetivos para KPIs
     DIAS_INVENTARIO_OBJETIVO: float = float(os.getenv("DIAS_INVENTARIO_OBJETIVO", "15"))
-    OBJETIVO_CUMPLIMIENTO_PLAN: float = float(os.getenv("OBJETIVO_CUMPLIMIENTO_PLAN", "0.95"))
+    OBJETIVO_CUMPLIMIENTO_PLAN: float = float(
+        os.getenv("OBJETIVO_CUMPLIMIENTO_PLAN", "0.95")
+    )
     OBJETIVO_OTD: float = float(os.getenv("OBJETIVO_OTD", "0.98"))
     OBJETIVO_RECHAZOS: float = float(os.getenv("OBJETIVO_RECHAZOS", "0.02"))
-    
+
     class Config:
         env_file = ".env"
         case_sensitive = True
+
 
 # Instancia de configuración
 settings = Settings()

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,6 +4,7 @@ sqlmodel
 prophet
 pandas
 python-dotenv
+pydantic-settings
 ruff
 black
 pytest


### PR DESCRIPTION
## Summary
- import `BaseSettings` from `pydantic_settings`
- add `pydantic-settings` dependency
- document new requirement in README

## Testing
- `black server/app/core/config.py --check`
- `ruff check server/app/core/config.py`


------
https://chatgpt.com/codex/tasks/task_e_684be23c00a483339cb0eef072cd2b1d